### PR TITLE
fix(cacheprovider.ts): move CacheManager singleton to register() inst…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@skrenek/cache-adonisjs",
+  "name": "@zeytech/cache-adonisjs",
   "version": "1.0.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@skrenek/cache-adonisjs",
+      "name": "@zeytech/cache-adonisjs",
       "version": "1.0.15",
       "license": "MIT",
       "devDependencies": {

--- a/providers/CacheProvider.ts
+++ b/providers/CacheProvider.ts
@@ -25,14 +25,14 @@ export default class CacheProvider {
       const CacheItem = require('../src/Cache/CacheItem')
       return CacheItem
     })
-  }
 
-  public boot() {
     this.app.container.singleton('Adonis/Addons/Zeytech/Cache/CacheManager', () => {
       const redis = this.app.container.use('Adonis/Addons/Redis')
       return new CacheManager(redis)
     })
   }
+
+  public boot() {}
 
   public async shutdown() {
     await this.app.container.resolveBinding('Adonis/Addons/Zeytech/Cache/CacheManager').shutdown()


### PR DESCRIPTION
…ead of boot()

Other modules depending on the CacheManager fail with IocLookupException, the namespace could not
resolved.

<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Other modules depending on the CacheManager fail with IocLookupException, the namespace could not
resolved.

Unsure of side effects or if this is the best solution.

## Types of changes

Changes when the CacheManager is registered.

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/skrenek/cache-adonisjs/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
